### PR TITLE
Update generators.js

### DIFF
--- a/tools/generators.js
+++ b/tools/generators.js
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import EventSource from 'eventsource';
+import { EventSource } from 'eventsource';
 import WebSocket from 'ws';
 import fs from 'fs';
 


### PR DESCRIPTION
file:///C:/Users/AB350-PRO4/source/repos/Gemini-Discord-Bot/tools/generators.js:2 import EventSource from 'eventsource';
       ^^^^^^^^^^^
SyntaxError: The requested module 'eventsource' does not provide an export named 'default'
    at ModuleJob._instantiate (node:internal/modules/esm/module_job:180:21)
    at async ModuleJob.run (node:internal/modules/esm/module_job:263:5)
    at async onImport.tracePromise.proto  (node:internal/modules/esm/loader:547:26)
    at async asyncRunEntryPointWithESMLoader (node:internal/modules/run_main:116:5)

I modified it to use import {EventSource} from 'eventsource';. After making this change, the problem no longer occurred.